### PR TITLE
Update pack format to 6

### DIFF
--- a/src/main/resources/pack.mcmeta
+++ b/src/main/resources/pack.mcmeta
@@ -1,7 +1,6 @@
 {
     "pack": {
-        "description": "examplemod resources",
-        "pack_format": 5,
-        "_comment": "A pack_format of 5 requires json lang files and some texture changes from 1.15. Note: we require v5 pack meta for all mods."
+        "description": "TipTheScales resources",
+        "pack_format": 6
     }
 }


### PR DESCRIPTION
Updates the `pack_format` in `pack.mcmeta` to `6`, which is the pack format starting from 1.16.2 up to today<sup>[1](#format)</sup>.
Also fixes the mod name in `description`, and removes the `_comment` comment.

<sup><a id="format">1. </a>[**Resource Pack § History**](https://minecraft.gamepedia.com/Resource_Pack#History) from _minecraft.gamepedia.com_: `1.16.2 | Release Candidate 1 | Changed format number to 6, due to changes to wall blocks made in 1.16 according to MC-197275.`; [MC-197275](https://bugs.mojang.com/browse/MC-197275)</sup>